### PR TITLE
Update .trigger-openshift-ci

### DIFF
--- a/.trigger-openshift-ci
+++ b/.trigger-openshift-ci
@@ -1,3 +1,3 @@
 When the `build-harness-extensions` repo is updated, increment this counter to trigger a new image builder build in OpenShift CI.
 
-0032
+0033


### PR DESCRIPTION
Debugging missing go1.14 image in openshift ci build cluster registry