### PR TITLE
kind.tf: fixes for terraform-aws-security-group v6

### DIFF
--- a/Dockerfile.go1.25-linux
+++ b/Dockerfile.go1.25-linux
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/tmp \
     GOPATH=/go \
-    GOVERSION=1.25.9 \
+    GOVERSION=1.25.11 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
     PATH=/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin

--- a/Dockerfile.go1.26-linux
+++ b/Dockerfile.go1.26-linux
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/tmp \
     GOPATH=/go \
-    GOVERSION=1.26.2 \
+    GOVERSION=1.26.4 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
     PATH=/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin

--- a/kind/kind.tf
+++ b/kind/kind.tf
@@ -16,7 +16,16 @@ module "ssh_sg" {
   description = "Prow KinD SG: allows inboud ssh from everywhere"
   vpc_id = data.aws_vpc.default.id
   
-  ingress_cidr_blocks =["0.0.0.0/0"]
+  ingress_cidr_ipv4 = {
+    vpc = "0.0.0.0/0"
+  }
+
+  egress_rules = {
+    all = {
+      ip_protocol = "-1"
+      cidr_ipv4   = "0.0.0.0/0"
+    }
+  }
 }
 
 # Create the key pair for use with ssh
@@ -41,7 +50,7 @@ resource "aws_instance" "kind" {
   ami           = data.aws_ami.kind_image.id
   instance_type = var.aws_instance_type 
   key_name      = aws_key_pair.kind.key_name
-  vpc_security_group_ids = [ module.ssh_sg.security_group_id ]
+  vpc_security_group_ids = [ module.ssh_sg.id ]
 
   tags = {
     Name = "prow-kind-${random_id.suffix.hex}"


### PR DESCRIPTION
A new release of terraform-aws-security-group was released, which caused a few breaking changes.

- `ingress_cidr_blocks` was removed, so was replaced with `ingress_cidr_ipv4`.
- `security_group_id` was renamed to `id`

Should fix e2e-kind tests that are currently failing with:

```
   on kind.tf line 19, in module "ssh_sg":
   19:   ingress_cidr_blocks =["0.0.0.0/0"]

 An argument named "ingress_cidr_blocks" is not expected here.
```

ref: https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/master/docs/UPGRADE-6.0.md

**Note: unsure how to test this properly, but the syntax errors are gone at least**