### PR TITLE
fix: install Java 21 for SonarScanner runtime (ACM-38055)

### DIFF
--- a/Dockerfile.go1.25-linux
+++ b/Dockerfile.go1.25-linux
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/tmp \
     GOPATH=/go \
-    GOVERSION=1.25.11 \
+    GOVERSION=1.25.12 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
     PATH=/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin

--- a/Dockerfile.go1.26-linux
+++ b/Dockerfile.go1.26-linux
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/tmp \
     GOPATH=/go \
-    GOVERSION=1.26.4 \
+    GOVERSION=1.26.5 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
     PATH=/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin

--- a/build/setup-sonar.sh
+++ b/build/setup-sonar.sh
@@ -11,7 +11,7 @@ sonar_url="https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/${son
 
 # Install dependencies from yum
 yum install -y \
-    java-17-openjdk-headless \
+    java-21-openjdk-headless \
     zip
 yum clean all
 


### PR DESCRIPTION
## Summary
- SonarQube Cloud no longer accepts Java 17 as the scanner runtime (effective 2026-07-20).
- `build/setup-sonar.sh` installed `java-17-openjdk-headless`, so all current `stolostron/builder` tags fail `sonar/go/prow`.
- Switch to `java-21-openjdk-headless`.

## Why
Unblocks `ci/prow/sonar` for repos using these builders, including [hypershift-addon-operator#759](https://github.com/stolostron/hypershift-addon-operator/pull/759).

Jira: https://redhat.atlassian.net/browse/ACM-38055

## Test plan
- [ ] Image-builder CI builds go1.23/1.24/1.25/1.26 images successfully
- [ ] After promotion, `java -version` in builder image reports 21+
- [ ] A dependent repo `ci/prow/sonar` job passes


Made with [Cursor](https://cursor.com)